### PR TITLE
Using ubuntu instead of windows for actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2.2.0
@@ -12,19 +12,19 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1.5.0
       with:
-        dotnet-version: '3.1'
+        dotnet-version: 3.1
 
     - name: Install dependencies
       run: dotnet restore
 
     - name: Build
-      run: dotnet publish -c Release -o "${{github.workspace}}/Release" "NorthwoodLib"
-      
+      run: dotnet publish -c Release -o Release NorthwoodLib
+
     - name: Test
       run: dotnet test
-        
+
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2.0.1
       with:
         name: NorthwoodLib
-        path: ${{github.workspace}}/Release
+        path: Release


### PR DESCRIPTION
Action performance is 1.5x faster on ubuntu than on windows.
Instead of 2 minutes and 20 seconds (last commit), the action takes less than half a minute.